### PR TITLE
point link to OSC home instead of pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ frequently used in *OpenSCAD*.
 
 # Dependencies
 
-* [OpenCASCADE Community Edition (OCE)](https://github.com/tpaviot/oce/pulls)
+* [OpenCASCADE Community Edition (OCE)](https://github.com/tpaviot/oce)
 * pythonocc-core
 * python-vtk6
 


### PR DESCRIPTION
I assume you intended the link to point to OSC github home rather than the pulls page. 
This is a great project, thank you!